### PR TITLE
第31回　CloudFormationを使った運用監視の環境構築

### DIFF
--- a/build/aws-study.yaml
+++ b/build/aws-study.yaml
@@ -12,7 +12,12 @@ Parameters:
     Type: String
     MinLength: 8
     Description: "The database admin password"
-#resourse
+
+  NamePrefix:
+    Type: String
+    Default: aws-study
+    Description: "リソース名の接頭辞（小文字推奨）"
+
 Resources:
   MyVPC:
     Type: AWS::EC2::VPC
@@ -82,6 +87,7 @@ Resources:
 
   MyRoute:
     Type: AWS::EC2::Route
+    DependsOn: AttachGateway
     Properties:
       RouteTableId: !Ref MyRouteTable
       DestinationCidrBlock: 0.0.0.0/0
@@ -169,7 +175,7 @@ Resources:
       SecurityGroups:
         - !Ref ALBSecurityGroup
 
-  #ALBリスナー(80で受けて8080で転送)
+  # ALBリスナー(80で受けて8080で転送)
   MyListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -190,7 +196,6 @@ Resources:
 
   MyRDSInstance:
     Type: AWS::RDS::DBInstance
-    DeletionPolicy: Snapshot
     Properties:
       Engine: mysql
       EngineVersion: "8.0"
@@ -202,3 +207,75 @@ Resources:
       VPCSecurityGroups:
         - !Ref RDSSecurityGroup
       PubliclyAccessible: false
+
+  EC2CPUUtilizationAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: "aws-study-cpu-utilization-alarm"
+      AlarmDescription: "Aws-Study EC2のCPU使用率が70%以上になりました。"
+      Namespace: "AWS/EC2"
+      Dimensions:
+        - Name: "InstanceId"
+          Value: !Ref MyEC2Instance
+      MetricName: "CPUUtilization"
+      Unit: "Percent"
+      Period: 300
+      Statistic: "Average"
+      Threshold: 70
+      ComparisonOperator: "GreaterThanOrEqualToThreshold"
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 2
+      TreatMissingData: "missing"
+      ActionsEnabled: true
+      AlarmActions:
+        - arn:aws:sns:ap-northeast-1:913925038760:AWS-Study-Topic
+
+  # Web ACL本体
+  MyWebACL:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      Name: !Sub "${NamePrefix}-waf"
+      Scope: REGIONAL
+      DefaultAction:
+        Allow: {}
+      Description: "AWS-Study Web ACL for ALB"
+      VisibilityConfig:
+        SampledRequestsEnabled: true
+        CloudWatchMetricsEnabled: true
+        MetricName: !Sub "${NamePrefix}-waf"
+      Rules:
+        - Name: "AWSCommonRules"
+          Priority: 1
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: "AWS"
+              Name: "AWSManagedRulesCommonRuleSet"
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Sub "${NamePrefix}-common-rules"
+
+  # Web ACLとALBの関連付け
+  MyWebACLAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    DependsOn: MyLoadBalancer # ← 追加（安定化）
+    Properties:
+      ResourceArn: !Ref MyLoadBalancer
+      WebACLArn: !GetAtt MyWebACL.Arn
+
+  #ロググループ
+  WAFLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "aws-waf-logs-${NamePrefix}-waf"
+      RetentionInDays: 7
+
+  # ログ設定
+  MyWebACLLoggingConfiguration:
+    Type: AWS::WAFv2::LoggingConfiguration
+    Properties:
+      ResourceArn: !GetAtt MyWebACL.Arn
+      LogDestinationConfigs:
+        - !GetAtt WAFLogGroup.Arn

--- a/build/aws-study.yaml
+++ b/build/aws-study.yaml
@@ -12,7 +12,7 @@ Parameters:
     Type: String
     MinLength: 8
     Description: "The database admin password"
-
+#resourse
 Resources:
   MyVPC:
     Type: AWS::EC2::VPC

--- a/build/aws-study.yaml
+++ b/build/aws-study.yaml
@@ -208,6 +208,12 @@ Resources:
         - !Ref RDSSecurityGroup
       PubliclyAccessible: false
 
+  MySNSTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: "Alarm Notification"
+      TopicName: !Sub "${NamePrefix}-alarm-topic"
+
   EC2CPUUtilizationAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -262,7 +268,7 @@ Resources:
     Type: AWS::WAFv2::WebACLAssociation
     DependsOn: MyLoadBalancer # ← 追加（安定化）
     Properties:
-      ResourceArn: !Ref MyLoadBalancer
+      ResourceArn: !GetAtt MyLoadBalancer.LoadBalancerArn
       WebACLArn: !GetAtt MyWebACL.Arn
 
   #ロググループ
@@ -275,6 +281,9 @@ Resources:
   # ログ設定
   MyWebACLLoggingConfiguration:
     Type: AWS::WAFv2::LoggingConfiguration
+    DependsOn:
+      - MyWebACL
+      - WAFLogGroup
     Properties:
       ResourceArn: !GetAtt MyWebACL.Arn
       LogDestinationConfigs:


### PR DESCRIPTION
<img width="1512" height="982" alt="スクリーンショット 2025-09-14 19 36 45" src="https://github.com/user-attachments/assets/be55b734-b649-4ec7-b7e8-3a35b3347840" />
<img width="1512" height="982" alt="スクリーンショット 2025-09-14 19 37 44" src="https://github.com/user-attachments/assets/43c8ce8d-c5ef-4ef4-9eae-fb8c28c48baf" />
<img width="1512" height="982" alt="スクリーンショット 2025-09-14 19 38 08" src="https://github.com/user-attachments/assets/2dba7c3d-0b3e-4887-b06a-e9527a029e1d" />
<img width="1512" height="982" alt="スクリーンショット 2025-09-14 19 41 23" src="https://github.com/user-attachments/assets/e30199c6-afd3-4aa9-a059-5f75f4e5e362" />
**実装内容**
EC2 に対する CPU 使用率 CloudWatch Alarm の追加（70%以上でアラート）
ALB の作成と、それに紐づく WAF WebACL の追加
WAF WebACL のログを CloudWatch Logs に出力する設定の追加
**工夫した点・学んだこと**
当初、WAF Logging 設定で「ARN が無効」というエラーが発生したが、原因は CloudWatch LogGroup 名のフォーマットミス（aws-waf-logs-○○○ の形式にする必要あり）だった。
ARN 書き換えを繰り返していたが、根本は命名規則の問題と気づいて解決。
CloudFormation での WAF ログ出力設定では Firehose を使わず直接 CloudWatch Logs に出力可能 なことを学んだ。
失敗しながらも調査を繰り返すことで、「公式ドキュメントの細かい仕様確認が大事」だと実感。