### PR TITLE
第33回 Terraformを使ったインフラのコード化と自動化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude override files as they are usually used to override resources locally
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include tfplan files to ignore plan output of command: terraform plan -out=tfplan
+*.tfplan
+
+# Lock file (optional: keep this if you want reproducible builds)
+.terraform.lock.hcl
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,371 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.50"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+# ====================================
+# Variables（CloudFormation Parameters相当）
+# ====================================
+variable "region" {
+  default = "ap-northeast-1"
+}
+
+variable "key_name" {
+  description = "EC2 Key Pair"
+  default     = "takatoseki"
+}
+
+variable "db_password" {
+  description = "The database admin password"
+  type        = string
+  sensitive   = true
+}
+
+variable "name_prefix" {
+  default = "aws-study"
+}
+
+variable "allowed_ssh_cidr" {
+  default = "221.49.49.27/32"
+}
+
+# ====================================
+# Networking (VPC, Subnets, IGW, Routes)
+# ====================================
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags = {
+    Name    = "MyVPC"
+    Project = var.name_prefix
+  }
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+  tags                    = { Name = "PublicSubnet1" }
+}
+
+resource "aws_subnet" "public_c" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.2.0/24"
+  availability_zone       = "ap-northeast-1c"
+  map_public_ip_on_launch = true
+  tags                    = { Name = "PublicSubnet2" }
+}
+
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.10.0/24"
+  availability_zone = "ap-northeast-1a"
+  tags              = { Name = "PrivateSubnet1" }
+}
+
+resource "aws_subnet" "private_c" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.11.0/24"
+  availability_zone = "ap-northeast-1c"
+  tags              = { Name = "PrivateSubnet2" }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_route" "default" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+}
+
+resource "aws_route_table_association" "public_a" {
+  subnet_id      = aws_subnet.public_a.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public_c" {
+  subnet_id      = aws_subnet.public_c.id
+  route_table_id = aws_route_table.public.id
+}
+
+# ====================================
+# Security Groups
+# ====================================
+resource "aws_security_group" "alb" {
+  name        = "${var.name_prefix}-alb-sg"
+  description = "ALB Security Group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "ec2" {
+  name        = "${var.name_prefix}-ec2-sg"
+  description = "EC2 Security Group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 22
+    to_port     = 22
+    cidr_blocks = [var.allowed_ssh_cidr]
+  }
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 8080
+    to_port         = 8080
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${var.name_prefix}-rds-sg"
+  description = "RDS Security Group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 3306
+    to_port         = 3306
+    security_groups = [aws_security_group.ec2.id]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ====================================
+# EC2 Instance
+# ====================================
+data "aws_ami" "al2" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_instance" "web" {
+  ami                         = data.aws_ami.al2.id
+  instance_type               = "t2.micro"
+  key_name                    = var.key_name
+  subnet_id                   = aws_subnet.public_a.id
+  vpc_security_group_ids      = [aws_security_group.ec2.id]
+  associate_public_ip_address = true
+
+  tags = { Name = "${var.name_prefix}-ec2" }
+}
+
+# ====================================
+# Application Load Balancer
+# ====================================
+resource "aws_lb" "this" {
+  name               = "MyALB"
+  load_balancer_type = "application"
+  internal           = false
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = [aws_subnet.public_a.id, aws_subnet.public_c.id]
+}
+
+resource "aws_lb_target_group" "tg" {
+  name     = "${var.name_prefix}-tg"
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.main.id
+
+  health_check {
+    path = "/"
+  }
+}
+
+resource "aws_lb_target_group_attachment" "attach" {
+  target_group_arn = aws_lb_target_group.tg.arn
+  target_id        = aws_instance.web.id
+  port             = 8080
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.tg.arn
+  }
+}
+
+# ====================================
+# RDS (MySQL)
+# ====================================
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.name_prefix}-db-subnet"
+  subnet_ids = [aws_subnet.private_a.id, aws_subnet.private_c.id]
+}
+
+resource "aws_db_instance" "this" {
+  identifier             = "${var.name_prefix}-db"
+  engine                 = "mysql"
+  engine_version         = "8.0"
+  instance_class         = "db.t3.micro"
+  allocated_storage      = 20
+  username               = "admin"
+  password               = var.db_password
+  db_subnet_group_name   = aws_db_subnet_group.this.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  publicly_accessible    = false
+  skip_final_snapshot    = true
+  apply_immediately      = true
+}
+
+# ====================================
+# SNS & CloudWatch Alarm
+# ====================================
+resource "aws_sns_topic" "alarm" {
+  name         = "${var.name_prefix}-alarm-topic"
+  display_name = "Alarm Notification"
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu_util" {
+  alarm_name        = "${var.name_prefix}-cpu-util-alarm"
+  alarm_description = "EC2 CPU usage >= 70%"
+  namespace         = "AWS/EC2"
+  metric_name       = "CPUUtilization"
+  dimensions = {
+    InstanceId = aws_instance.web.id
+  }
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 2
+  threshold           = 70
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "missing"
+  alarm_actions       = [aws_sns_topic.alarm.arn]
+}
+
+# ====================================
+# WAF (Web ACL + Logs)
+# ====================================
+resource "aws_wafv2_web_acl" "this" {
+  name  = "${var.name_prefix}-waf"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  description = "AWS-Study Web ACL for ALB"
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.name_prefix}-waf"
+    sampled_requests_enabled   = true
+  }
+
+  rule {
+    name     = "AWSCommonRules"
+    priority = 1
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    override_action {
+      none {}
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.name_prefix}-common-rules"
+      sampled_requests_enabled   = true
+    }
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "alb_assoc" {
+  resource_arn = aws_lb.this.arn
+  web_acl_arn  = aws_wafv2_web_acl.this.arn
+}
+
+resource "aws_cloudwatch_log_group" "waf" {
+  name              = "aws-waf-logs-${var.name_prefix}-waf"
+  retention_in_days = 7
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "waf_logs" {
+  resource_arn            = aws_wafv2_web_acl.this.arn
+  log_destination_configs = [aws_cloudwatch_log_group.waf.arn]
+}
+
+# ====================================
+# Outputs
+# ====================================
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer"
+  value       = aws_lb.this.dns_name
+}
+
+output "ec2_public_ip" {
+  description = "Public IP of the EC2 instance"
+  value       = aws_instance.web.public_ip
+}
+
+output "rds_endpoint" {
+  description = "RDS endpoint to connect to the database"
+  value       = aws_db_instance.this.endpoint
+}
+
+output "rds_username" {
+  description = "RDS master username"
+  value       = aws_db_instance.this.username
+}
+
+output "rds_db_name" {
+  description = "RDS database name"
+  value       = aws_db_instance.this.db_name
+}
+

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,6 @@
+region           = "ap-northeast-1"
+name_prefix      = "aws-study"
+key_name         = "takatoseki"
+allowed_ssh_cidr = "221.49.49.27/32"
+db_password      = "13460314zX!"
+

--- a/terraform/y
+++ b/terraform/y
@@ -1,0 +1,238 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.50"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+locals {
+  tags = {
+    Project = var.name_prefix
+  }
+}
+# ────────────────────────────────────────────────
+# Networking (VPC, Subnets, IGW, RouteTable)
+# ────────────────────────────────────────────────
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags = merge(local.tags, { Name = "MyVPC" })
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+  tags   = local.tags
+}
+
+# Public subnets (1a, 1c)
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+  tags = merge(local.tags, { Name = "PublicSubnet1" })
+}
+
+resource "aws_subnet" "public_c" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.2.0/24"
+  availability_zone       = "ap-northeast-1c"
+  map_public_ip_on_launch = true
+  tags = merge(local.tags, { Name = "PublicSubnet2" })
+}
+
+# Private subnets (1a, 1c)
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.10.0/24"
+  availability_zone = "ap-northeast-1a"
+  tags              = merge(local.tags, { Name = "PrivateSubnet1" })
+}
+
+resource "aws_subnet" "private_c" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.11.0/24"
+  availability_zone = "ap-northeast-1c"
+  tags              = merge(local.tags, { Name = "PrivateSubnet2" })
+}
+
+# Route table for public subnets
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+  tags   = local.tags
+}
+
+resource "aws_route" "default_igw" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+  depends_on             = [aws_internet_gateway.igw]
+}
+
+resource "aws_route_table_association" "assoc_public_a" {
+  subnet_id      = aws_subnet.public_a.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "assoc_public_c" {
+  subnet_id      = aws_subnet.public_c.id
+  route_table_id = aws_route_table.public.id
+}
+# ────────────────────────────────────────────────
+# Security Groups
+# ────────────────────────────────────────────────
+
+resource "aws_security_group" "alb" {
+  name        = "${var.name_prefix}-alb-sg"
+  description = "ALB Security Group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags
+}
+
+resource "aws_security_group" "ec2" {
+  name        = "${var.name_prefix}-ec2-sg"
+  description = "EC2 Security Group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 22
+    to_port     = 22
+    cidr_blocks = [var.allowed_ssh_cidr]
+  }
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 8080
+    to_port         = 8080
+    security_groups = [aws_security_group.alb.id]
+    description     = "From ALB"
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${var.name_prefix}-rds-sg"
+  description = "RDS Security Group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 3306
+    to_port         = 3306
+    security_groups = [aws_security_group.ec2.id]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags
+}
+# ────────────────────────────────────────────────
+# Compute (EC2)
+# ────────────────────────────────────────────────
+
+# 最新のAmazon Linux 2を取得
+data "aws_ami" "al2" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_instance" "web" {
+  ami                         = data.aws_ami.al2.id
+  instance_type               = "t2.micro"
+  subnet_id                   = aws_subnet.public_a.id
+  vpc_security_group_ids      = [aws_security_group.ec2.id]
+  key_name                    = var.key_name
+  associate_public_ip_address = true
+
+  tags = merge(local.tags, { Name = "${var.name_prefix}-ec2" })
+}
+# ────────────────────────────────────────────────
+# Application Load Balancer (ALB)
+# ────────────────────────────────────────────────
+
+resource "aws_lb" "this" {
+  name               = "MyALB"
+  load_balancer_type = "application"
+  internal           = false
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = [aws_subnet.public_a.id, aws_subnet.public_c.id]
+  tags               = local.tags
+}
+
+resource "aws_lb_target_group" "tg" {
+  name     = "${var.name_prefix}-tg"
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.main.id
+
+  health_check {
+    path = "/"
+  }
+
+  tags = local.tags
+}
+
+resource "aws_lb_target_group_attachment" "attach" {
+  target_group_arn = aws_lb_target_group.tg.arn
+  target_id        = aws_instance.web.id
+  port             = 8080
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.tg.arn
+  }
+}
+


### PR DESCRIPTION
<img width="464" height="119" alt="スクリーンショット 2025-09-16 23 47 27" src="https://github.com/user-attachments/assets/fb2d782d-7976-47d8-bfc2-daf82abc89ea" />

### **実装内容**
Terraform を用いて以下のリソースを構築
VPC（Public / Private サブネットを複数AZに作成）
Internet Gateway / Route Table 設定
ALB（Application Load Balancer）＋ Target Group ＋ Listener
EC2 インスタンス（Public Subnet配置、ALB配下に登録）
RDS (MySQL) インスタンス（Private Subnet配置）
Security Group（ALB、EC2、RDS 間のアクセス制御）
SNS Topic（アラーム通知用）
CloudWatch Alarm（EC2 CPU使用率監視）
WAF（AWS Managed Rules を ALB にアタッチ）＋ WAF ログ出力（CloudWatch Logs）


### **工夫した点・学んだこと**
CloudFormation の構成を Terraform にまとめ、main.tf に集約して管理しやすくした
変数・outputs を使って環境依存の値を外部化し、再利用しやすい構成にした
WAF ログや CloudWatch Alarm を追加し、監視・セキュリティも考慮した
Terraform と CloudFormation の書き方の違い（参照方法など）
ALB と EC2 間の疎通や WAF の関連付けの仕組み
CloudWatch Alarm の細かい設定（missing データ扱いなど）の重要性
